### PR TITLE
Do not memorize reply-to queue.

### DIFF
--- a/bunny_burrow.gemspec
+++ b/bunny_burrow.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'dotenv'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-nav'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/bunny_burrow/client.rb
+++ b/lib/bunny_burrow/client.rb
@@ -5,6 +5,11 @@ module BunnyBurrow
     def publish(payload, routing_key)
       result = nil
 
+      # when creating a queue, a blank name indicates we want the AMPQ broker
+      # to generate a unique name for us. Also note that this queue will be on
+      # the default exchange
+      reply_to = channel.queue('', exclusive: true, auto_delete: true)
+
       details = {
         routing_key: routing_key,
         reply_to: reply_to
@@ -32,15 +37,6 @@ module BunnyBurrow
       end
 
       result
-    end
-
-    private
-
-    def reply_to
-      # when creating a queue, a blank name indicates we want the AMPQ broker
-      # to generate a unique name for us. Also note that this queue will be on
-      # the default exchange
-      @reply_to ||= channel.queue('', exclusive: true, auto_delete: true)
     end
   end
 end

--- a/lib/bunny_burrow/version.rb
+++ b/lib/bunny_burrow/version.rb
@@ -1,3 +1,3 @@
 module BunnyBurrow
-  VERSION = '1.4.0'
+  VERSION = '1.5.0'
 end

--- a/spec/lib/bunny_burrow/client_spec.rb
+++ b/spec/lib/bunny_burrow/client_spec.rb
@@ -31,7 +31,7 @@ describe BunnyBurrow::Client do
       allow(reply_to).to receive(:subscribe).and_yield({}, {}, response)
       allow(subject).to receive(:condition).and_return(condition)
       allow(subject).to receive(:log)
-      allow(channel).to receive(:queue).with("", {:exclusive=>true, :auto_delete=>true}).and_return(reply_to)
+      allow(channel).to receive(:queue).and_return(reply_to)
       allow(topic_exchange).to receive(:publish)
     end
 

--- a/spec/lib/bunny_burrow/client_spec.rb
+++ b/spec/lib/bunny_burrow/client_spec.rb
@@ -16,21 +16,7 @@ describe BunnyBurrow::Client do
       expect(subject.class.ancestors).to include(BunnyBurrow::Base)
     end
 
-    it 'creates a reply-to queue if one does not exist' do
-      subject.instance_variable_set('@reply_to', nil)
-      options = {
-        exclusive: true,
-        auto_delete: true
-      }
-      expect(channel).to receive(:queue).with('', hash_including(options))
-      subject.send :reply_to
-    end
 
-    it 'uses existing reply-to queue' do
-      subject.instance_variable_set('@reply_to', reply_to)
-      expect(channel).not_to receive(:queue)
-      subject.send :reply_to
-    end
   end # describe 'instance'
 
   describe '#publish' do
@@ -45,7 +31,7 @@ describe BunnyBurrow::Client do
       allow(reply_to).to receive(:subscribe).and_yield({}, {}, response)
       allow(subject).to receive(:condition).and_return(condition)
       allow(subject).to receive(:log)
-      allow(subject).to receive(:reply_to).and_return(reply_to)
+      allow(channel).to receive(:queue).with("", {:exclusive=>true, :auto_delete=>true}).and_return(reply_to)
       allow(topic_exchange).to receive(:publish)
     end
 
@@ -68,6 +54,15 @@ describe BunnyBurrow::Client do
     it 'logs publishing details with the request' do
       allow(subject).to receive(:log_request?).and_return(true)
       expect(subject).to receive(:log).with(/^Publishing(?=.*request).*/)
+      subject.publish request, routing_key
+    end
+
+    it 'creates a reply-to queue ' do
+      options = {
+        exclusive: true,
+        auto_delete: true
+      }
+      expect(channel).to receive(:queue).with('', hash_including(options))
       subject.publish request, routing_key
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,9 @@
+# Use Dotenv to load the environment when executing with IntelliJ.
+if ENV['RM_INFO']
+  require 'dotenv'
+  Dotenv.load File.expand_path('../../.env.test', __FILE__)
+end
+
 require 'pry'
 require 'simplecov'
 require 'simplecov-rcov'


### PR DESCRIPTION
Do not memorize reply-to queue.
Add dotenv to development dependencies
Add code snippet to spec helper so specs can be run from IntelliJ.